### PR TITLE
feat: add resource manager for separate DHT libp2p host

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -199,11 +199,18 @@ func Setup(ctx context.Context, cfg Config, key crypto.PrivKey, dnsCache *cached
 			if cfg.DHTSharedHost {
 				dhtHost = h
 			} else {
+				dhtLimiter := rcmgr.NewFixedLimiter(makeResourceManagerConfig(cfg.MaxMemory, cfg.MaxFD, cfg.ConnMgrHi))
+				dhtMgr, err := rcmgr.NewResourceManager(dhtLimiter)
+				if err != nil {
+					return nil, err
+				}
+
 				dhtHost, err = libp2p.New(
 					libp2p.NoListenAddrs,
 					libp2p.BandwidthReporter(bwc),
 					libp2p.DefaultTransports,
 					libp2p.DefaultMuxers,
+					libp2p.ResourceManager(dhtMgr),
 				)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
Seems like we need a separate resource manager for the DHT host if it's separate. For now I just reused the limits, but that's obviously not right since that would put the default memory usage at `0.85 * 2` of total memory and `0.5 *2` of total FDs.

Some notes:
- [x] We should be able to significantly throttle inbound streams and connections
- We could separate various flags (connmgr, memory, fd) flags for the new host if we wanted, but either way we need some sensible default percentages to allocate
- For some reason running before #35 does not result in resource manager errors from the accelerated DHT client (perhaps related to smart dialing?), but this change seems needed anyway

Thoughts?