### PR TITLE
feat: seed-based automatic peering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
+- ✨ Now supports automatic peering with peers that have the same seed via `--seed-peering` (`RAINBOW_SEED_PEERING`). To enable this, you must configure `--seed` (`RAINBOW_SEED`) and `--seed-index` (`RAINBOW_SEED_INDEX`).
+
 ### Changed
 
 ### Removed

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -10,6 +10,8 @@
   - [`RAINBOW_GC_THRESHOLD`](#rainbow_gc_threshold)
   - [`RAINBOW_IPNS_MAX_CACHE_TTL`](#rainbow_ipns_max_cache_ttl)
   - [`RAINBOW_PEERING`](#rainbow_peering)
+  - [`RAINBOW_SEED`](#rainbow_seed)
+  - [`RAINBOW_SEED_INDEX`](#rainbow_seed_index)
   - [`RAINBOW_SEED_PEERING`](#rainbow_seed_peering)
   - [`RAINBOW_SEED_PEERING_MAX_INDEX`](#rainbow_seed_peering_max_index)
   - [`RAINBOW_PEERING_SHARED_CACHE`](#rainbow_peering_shared_cache)
@@ -106,13 +108,29 @@ A comma-separated list of [multiaddresses](https://docs.libp2p.io/concepts/funda
 
 Default: not set (no peering)
 
+### `RAINBOW_SEED`
+
+Base58 seed to derive PeerID from. Can be generated with `rainbow gen-seed`.
+If set, requires `RAINBOW_SEED_INDEX` to be set as well.
+
+Default: not set
+
+### `RAINBOW_SEED_INDEX`
+
+Index to derivate the PeerID identity from `RAINBOW_SEED`.
+
+Default: not set
+
 ### `RAINBOW_SEED_PEERING`
+
+> [!WARNING]
+> Experimental feature.
 
 Automated version of `RAINBOW_PEERING` which does not require providing multiaddrs.
 
 Instead, it will set up peering with peers that share the same seed (requires `RAINBOW_SEED_INDEX` to be set up).
 
-> [!WARNING]
+> [!NOTE]
 > Runs a separate light DHT for peer routing with the main host if DHT routing is disabled.
 
 Default: `false` (disabled)
@@ -120,21 +138,27 @@ Default: `false` (disabled)
 ### `RAINBOW_SEED_PEERING_MAX_INDEX`
 
 Informs the largest index to derive for `RAINBOW_SEED_PEERING`.
+If you have more instances than the default, increase it here.
 
 Default: 100
 
 ### `RAINBOW_PEERING_SHARED_CACHE`
 
-Enable sharing of local cache to peers safe-listed with `RAINBOW_PEERING`.
+> [!WARNING]
+> Experimental feature.
+
+Enable sharing of local cache to peers safe-listed with `RAINBOW_PEERING`
+or `RAINBOW_SEED_PEERING`.
 
 Once enabled, Rainbow will respond to [Bitswap](https://docs.ipfs.tech/concepts/bitswap/)
 queries from these safelisted peers, serving locally cached blocks if requested.
 
-The main use case for this feature is scaling and load balancing across a
-fleet of rainbow, or other bitswap-capable IPFS services. Cache sharing allows
-clustered services to check if any of the other instances has a requested CID.
-This saves resources as data cached on other instance can be fetched internally
-(e.g. LAN) rather than externally (WAN, p2p).
+> [!TIP]
+> The main use case for this feature is scaling and load balancing across a
+> fleet of rainbow, or other bitswap-capable IPFS services. Cache sharing allows
+> clustered services to check if any of the other instances has a requested CID.
+> This saves resources as data cached on other instance can be fetched internally
+> (e.g. LAN) rather than externally (WAN, p2p).
 
 Default: `false` (no cache sharing)
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -10,6 +10,8 @@
   - [`RAINBOW_GC_THRESHOLD`](#rainbow_gc_threshold)
   - [`RAINBOW_IPNS_MAX_CACHE_TTL`](#rainbow_ipns_max_cache_ttl)
   - [`RAINBOW_PEERING`](#rainbow_peering)
+  - [`RAINBOW_SEED_PEERING`](#rainbow_seed_peering)
+  - [`RAINBOW_SEED_PEERING_MAX_INDEX`](#rainbow_seed_peering_max_index)
   - [`RAINBOW_PEERING_SHARED_CACHE`](#rainbow_peering_shared_cache)
 - [Logging](#logging)
   - [`GOLOG_LOG_LEVEL`](#golog_log_level)
@@ -96,13 +98,30 @@ Default: No upper bound, [TTL from IPNS Record](https://specs.ipfs.tech/ipns/ipn
 
 A comma-separated list of [multiaddresses](https://docs.libp2p.io/concepts/fundamentals/addressing/) of peers to stay connected to.
 
-
-If `RAINBOW_SEED` is set and `/p2p/rainbow-seed/N` value is found here, Rainbow
-will replace it with a valid `/p2p/` for a peer ID generated from same seed
-and index `N`.
+> [!TIP]
+> If `RAINBOW_SEED` is set and `/p2p/rainbow-seed/N` value is found here, Rainbow
+> will replace it with a valid `/p2p/` for a peer ID generated from same seed
+> and index `N`. This is useful when `RAINBOW_SEED_PEERING` can't be used,
+> or when peer routing should be skipped and specific address should be used.
 
 Default: not set (no peering)
 
+### `RAINBOW_SEED_PEERING`
+
+Automated version of `RAINBOW_PEERING` which does not require providing multiaddrs.
+
+Instead, it will set up peering with peers that share the same seed (requires `RAINBOW_SEED_INDEX` to be set up).
+
+> [!WARNING]
+> Runs a separate light DHT for peer routing with the main host if DHT routing is disabled.
+
+Default: `false` (disabled)
+
+### `RAINBOW_SEED_PEERING_MAX_INDEX`
+
+Informs the largest index to derive for `RAINBOW_SEED_PEERING`.
+
+Default: 100
 
 ### `RAINBOW_PEERING_SHARED_CACHE`
 

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/libp2p/go-libp2p-kad-dht v0.25.2
 	github.com/libp2p/go-libp2p-record v0.2.0
 	github.com/libp2p/go-libp2p-routing-helpers v0.7.3
+	github.com/libp2p/go-libp2p-testing v0.12.0
 	github.com/mitchellh/go-server-timing v1.0.1
 	github.com/mr-tron/base58 v1.2.0
 	github.com/multiformats/go-multiaddr v0.12.3

--- a/keys.go
+++ b/keys.go
@@ -9,6 +9,7 @@ import (
 	"io"
 
 	libp2p "github.com/libp2p/go-libp2p/core/crypto"
+	peer "github.com/libp2p/go-libp2p/core/peer"
 	"github.com/mr-tron/base58"
 	"golang.org/x/crypto/hkdf"
 )
@@ -25,7 +26,7 @@ func newSeed() (string, error) {
 	return base58.Encode(bs), nil
 }
 
-// derive derives libp2p keys from a b58-encoded seed.
+// deriveKey derives libp2p keys from a b58-encoded seed.
 func deriveKey(b58secret string, info []byte) (libp2p.PrivKey, error) {
 	secret, err := base58.Decode(b58secret)
 	if err != nil {
@@ -43,6 +44,32 @@ func deriveKey(b58secret string, info []byte) (libp2p.PrivKey, error) {
 	}
 	key := ed25519.NewKeyFromSeed(keySeed)
 	return libp2p.UnmarshalEd25519PrivateKey(key)
+}
+
+// derivePeerIDs derives the peer IDs of all the peers with the same seed up to
+// maxIndex. Our peer ID (with index 'ourIndex') is not generated.
+func derivePeerIDs(seed string, ourIndex int, maxIndex int) ([]peer.ID, error) {
+	peerIDs := []peer.ID{}
+
+	for i := 0; i <= maxIndex; i++ {
+		if i == ourIndex {
+			continue
+		}
+
+		peerPriv, err := deriveKey(seed, deriveKeyInfo(i))
+		if err != nil {
+			return nil, err
+		}
+
+		pid, err := peer.IDFromPrivateKey(peerPriv)
+		if err != nil {
+			return nil, err
+		}
+
+		peerIDs = append(peerIDs, pid)
+	}
+
+	return peerIDs, nil
 }
 
 func deriveKeyInfo(index int) []byte {

--- a/main.go
+++ b/main.go
@@ -91,6 +91,29 @@ Generate an identity seed and launch a gateway:
 			EnvVars: []string{"RAINBOW_SEED_INDEX"},
 			Usage:   "Index to derivate the peerID (needs --seed)",
 		},
+		&cli.BoolFlag{
+			Name:    "seed-peering",
+			Value:   false,
+			EnvVars: []string{"RAINBOW_SEED_PEERING"},
+			Usage:   "Automatic peering with peers with the same seed (requires --seed and --seed-index). Runs a separate light DHT for peer routing with the main host if --dht-routing or --dht-shared-host are disabled",
+			Action: func(ctx *cli.Context, b bool) error {
+				if !b {
+					return nil
+				}
+
+				if !ctx.IsSet("seed") || !ctx.IsSet("seed-index") {
+					return errors.New("--seed and --seed-index must be explicitly defined when --seed-peering is enabled")
+				}
+
+				return nil
+			},
+		},
+		&cli.IntFlag{
+			Name:    "seed-peering-max-index",
+			Value:   100,
+			EnvVars: []string{"RAINBOW_SEED_PEERING_MAX_INDEX"},
+			Usage:   "Largest index to derive automatic peering peer IDs for",
+		},
 		&cli.StringSliceFlag{
 			Name:    "gateway-domains",
 			Value:   cli.NewStringSlice(),
@@ -338,6 +361,10 @@ share the same seed as long as the indexes are different.
 			DenylistSubs:            cctx.StringSlice("denylists"),
 			Peering:                 peeringAddrs,
 			PeeringCache:            cctx.Bool("peering-shared-cache"),
+			Seed:                    seed,
+			SeedIndex:               index,
+			SeedPeering:             cctx.Bool("seed-peering"),
+			SeedPeeringMaxIndex:     cctx.Int("seed-peering-max-index"),
 			GCInterval:              cctx.Duration("gc-interval"),
 			GCThreshold:             cctx.Float64("gc-threshold"),
 		}

--- a/setup.go
+++ b/setup.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -22,12 +21,9 @@ import (
 	"github.com/ipfs/boxo/blockstore"
 	bsfetcher "github.com/ipfs/boxo/fetcher/impl/blockservice"
 	"github.com/ipfs/boxo/gateway"
-	"github.com/ipfs/boxo/ipns"
 	"github.com/ipfs/boxo/namesys"
 	"github.com/ipfs/boxo/path/resolver"
 	"github.com/ipfs/boxo/peering"
-	routingv1client "github.com/ipfs/boxo/routing/http/client"
-	httpcontentrouter "github.com/ipfs/boxo/routing/http/contentrouter"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	badger4 "github.com/ipfs/go-ds-badger4"
@@ -38,21 +34,14 @@ import (
 	"github.com/ipfs/go-unixfsnode"
 	dagpb "github.com/ipld/go-codec-dagpb"
 	"github.com/libp2p/go-libp2p"
-	dht "github.com/libp2p/go-libp2p-kad-dht"
-	"github.com/libp2p/go-libp2p-kad-dht/fullrt"
-	record "github.com/libp2p/go-libp2p-record"
-	routinghelpers "github.com/libp2p/go-libp2p-routing-helpers"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/metrics"
-	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/routing"
 	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
 	"github.com/multiformats/go-multiaddr"
-	"go.opencensus.io/stats/view"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 func init() {
@@ -339,247 +328,6 @@ func setupDatastore(cfg Config) (datastore.Batching, error) {
 	default:
 		return nil, fmt.Errorf("unsupported blockstore type: %s", cfg.BlockstoreType)
 	}
-}
-
-func setupDelegatedRouting(cfg Config, dnsCache *cachedDNS) ([]routing.Routing, error) {
-	// Increase per-host connection pool since we are making lots of concurrent requests.
-	httpClient := &http.Client{
-		Transport: otelhttp.NewTransport(
-			&routingv1client.ResponseBodyLimitedTransport{
-				RoundTripper: &customTransport{
-					// Roundtripper with increased defaults than http.Transport such that retrieving
-					// multiple lookups concurrently is fast.
-					RoundTripper: &http.Transport{
-						MaxIdleConns:        1000,
-						MaxConnsPerHost:     100,
-						MaxIdleConnsPerHost: 100,
-						IdleConnTimeout:     90 * time.Second,
-						DialContext:         dnsCache.dialWithCachedDNS,
-						ForceAttemptHTTP2:   true,
-					},
-				},
-				LimitBytes: 1 << 20,
-			}),
-	}
-
-	var (
-		delegatedRouters []routing.Routing
-	)
-
-	for _, endpoint := range cfg.RoutingV1Endpoints {
-		rv1Opts := []routingv1client.Option{routingv1client.WithHTTPClient(httpClient)}
-		if endpoint != cidContactEndpoint {
-			rv1Opts = append(rv1Opts, routingv1client.WithStreamResultsRequired())
-		}
-		delegatedRouter, err := delegatedHTTPContentRouter(endpoint, rv1Opts...)
-		if err != nil {
-			return nil, err
-		}
-		delegatedRouters = append(delegatedRouters, delegatedRouter)
-	}
-
-	return delegatedRouters, nil
-}
-
-func setupDHTRouting(ctx context.Context, cfg Config, h host.Host, ds datastore.Batching, dhtRcMgr network.ResourceManager, bwc metrics.Reporter) (routing.Routing, error) {
-	if cfg.DHTRouting == DHTOff {
-		return nil, nil
-	}
-
-	var err error
-
-	var dhtHost host.Host
-	if cfg.DHTSharedHost {
-		dhtHost = h
-	} else {
-		dhtHost, err = libp2p.New(
-			libp2p.NoListenAddrs,
-			libp2p.BandwidthReporter(bwc),
-			libp2p.DefaultTransports,
-			libp2p.DefaultMuxers,
-			libp2p.ResourceManager(dhtRcMgr),
-		)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	standardClient, err := dht.New(ctx, dhtHost,
-		dht.Datastore(ds),
-		dht.BootstrapPeers(dht.GetDefaultBootstrapPeerAddrInfos()...),
-		dht.Mode(dht.ModeClient),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	if cfg.DHTRouting == DHTStandard {
-		return standardClient, nil
-	}
-
-	if cfg.DHTRouting == DHTAccelerated {
-		fullRTClient, err := fullrt.NewFullRT(dhtHost, dht.DefaultPrefix,
-			fullrt.DHTOption(
-				dht.Validator(record.NamespacedValidator{
-					"pk":   record.PublicKeyValidator{},
-					"ipns": ipns.Validator{KeyBook: h.Peerstore()},
-				}),
-				dht.Datastore(ds),
-				dht.BootstrapPeers(dht.GetDefaultBootstrapPeerAddrInfos()...),
-				dht.BucketSize(20),
-			))
-		if err != nil {
-			return nil, err
-		}
-		return &bundledDHT{
-			standard: standardClient,
-			fullRT:   fullRTClient,
-		}, nil
-	}
-
-	return nil, fmt.Errorf("unknown DHTRouting option: %q", cfg.DHTRouting)
-}
-
-func setupCompositeRouting(delegatedRouters []routing.Routing, dht routing.Routing) routing.Routing {
-	// Default router is no routing at all: can be especially useful during tests.
-	var router routing.Routing
-	router = &routinghelpers.Null{}
-
-	if len(delegatedRouters) == 0 && dht != nil {
-		router = dht
-	} else {
-		var routers []*routinghelpers.ParallelRouter
-
-		if dht != nil {
-			routers = append(routers, &routinghelpers.ParallelRouter{
-				Router:                  dht,
-				ExecuteAfter:            0,
-				DoNotWaitForSearchValue: true,
-				IgnoreError:             false,
-			})
-		}
-
-		for _, routingV1Router := range delegatedRouters {
-			routers = append(routers, &routinghelpers.ParallelRouter{
-				Timeout:                 15 * time.Second,
-				Router:                  routingV1Router,
-				ExecuteAfter:            0,
-				DoNotWaitForSearchValue: true,
-				IgnoreError:             true,
-			})
-		}
-
-		if len(routers) > 0 {
-			router = routinghelpers.NewComposableParallel(routers)
-		}
-	}
-
-	return router
-}
-
-func setupRouting(ctx context.Context, cfg Config, h host.Host, ds datastore.Batching, dhtRcMgr network.ResourceManager, bwc metrics.Reporter, dnsCache *cachedDNS) (routing.ContentRouting, routing.PeerRouting, routing.ValueStore, error) {
-	delegatedRouters, err := setupDelegatedRouting(cfg, dnsCache)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	dhtRouter, err := setupDHTRouting(ctx, cfg, h, ds, dhtRcMgr, bwc)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	router := setupCompositeRouting(delegatedRouters, dhtRouter)
-
-	var (
-		cr routing.ContentRouting = router
-		pr routing.PeerRouting    = router
-		vs routing.ValueStore     = router
-	)
-
-	// If we're using seed peering, we need to run a lighter Amino DHT for the
-	// peering routing. We need to run a separate DHT with the main host if
-	//  the shared host is disabled, or if we're not running any DHT at all.
-	if cfg.SeedPeering && (!cfg.DHTSharedHost || dhtRouter == nil) {
-		pr, err = dht.New(ctx, h,
-			dht.Datastore(ds),
-			dht.BootstrapPeers(dht.GetDefaultBootstrapPeerAddrInfos()...),
-			dht.Mode(dht.ModeClient),
-		)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-	}
-
-	return cr, pr, vs, nil
-}
-
-type bundledDHT struct {
-	standard *dht.IpfsDHT
-	fullRT   *fullrt.FullRT
-}
-
-func (b *bundledDHT) getDHT() routing.Routing {
-	if b.fullRT.Ready() {
-		return b.fullRT
-	}
-	return b.standard
-}
-
-func (b *bundledDHT) Provide(ctx context.Context, c cid.Cid, brdcst bool) error {
-	return b.getDHT().Provide(ctx, c, brdcst)
-}
-
-func (b *bundledDHT) FindProvidersAsync(ctx context.Context, c cid.Cid, i int) <-chan peer.AddrInfo {
-	return b.getDHT().FindProvidersAsync(ctx, c, i)
-}
-
-func (b *bundledDHT) FindPeer(ctx context.Context, id peer.ID) (peer.AddrInfo, error) {
-	return b.getDHT().FindPeer(ctx, id)
-}
-
-func (b *bundledDHT) PutValue(ctx context.Context, k string, v []byte, option ...routing.Option) error {
-	return b.getDHT().PutValue(ctx, k, v, option...)
-}
-
-func (b *bundledDHT) GetValue(ctx context.Context, s string, option ...routing.Option) ([]byte, error) {
-	return b.getDHT().GetValue(ctx, s, option...)
-}
-
-func (b *bundledDHT) SearchValue(ctx context.Context, s string, option ...routing.Option) (<-chan []byte, error) {
-	return b.getDHT().SearchValue(ctx, s, option...)
-}
-
-func (b *bundledDHT) Bootstrap(ctx context.Context) error {
-	return b.standard.Bootstrap(ctx)
-}
-
-var _ routing.Routing = (*bundledDHT)(nil)
-
-func delegatedHTTPContentRouter(endpoint string, rv1Opts ...routingv1client.Option) (routing.Routing, error) {
-	cli, err := routingv1client.New(
-		endpoint,
-		append([]routingv1client.Option{
-			routingv1client.WithUserAgent(buildVersion()),
-		}, rv1Opts...)...,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	cr := httpcontentrouter.NewContentRoutingClient(
-		cli,
-	)
-
-	err = view.Register(routingv1client.OpenCensusViews...)
-	if err != nil {
-		return nil, fmt.Errorf("registering HTTP delegated routing views: %w", err)
-	}
-
-	return &routinghelpers.Compose{
-		ValueStore:     cr,
-		PeerRouting:    cr,
-		ContentRouting: cr,
-	}, nil
 }
 
 func loadOrInitPeerKey(kf string) (crypto.PrivKey, error) {

--- a/setup_routing.go
+++ b/setup_routing.go
@@ -1,0 +1,267 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ipfs/boxo/ipns"
+	routingv1client "github.com/ipfs/boxo/routing/http/client"
+	httpcontentrouter "github.com/ipfs/boxo/routing/http/contentrouter"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/libp2p/go-libp2p"
+	dht "github.com/libp2p/go-libp2p-kad-dht"
+	"github.com/libp2p/go-libp2p-kad-dht/fullrt"
+	record "github.com/libp2p/go-libp2p-record"
+	routinghelpers "github.com/libp2p/go-libp2p-routing-helpers"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/metrics"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/routing"
+	"go.opencensus.io/stats/view"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+func setupDelegatedRouting(cfg Config, dnsCache *cachedDNS) ([]routing.Routing, error) {
+	// Increase per-host connection pool since we are making lots of concurrent requests.
+	httpClient := &http.Client{
+		Transport: otelhttp.NewTransport(
+			&routingv1client.ResponseBodyLimitedTransport{
+				RoundTripper: &customTransport{
+					// Roundtripper with increased defaults than http.Transport such that retrieving
+					// multiple lookups concurrently is fast.
+					RoundTripper: &http.Transport{
+						MaxIdleConns:        1000,
+						MaxConnsPerHost:     100,
+						MaxIdleConnsPerHost: 100,
+						IdleConnTimeout:     90 * time.Second,
+						DialContext:         dnsCache.dialWithCachedDNS,
+						ForceAttemptHTTP2:   true,
+					},
+				},
+				LimitBytes: 1 << 20,
+			}),
+	}
+
+	var (
+		delegatedRouters []routing.Routing
+	)
+
+	for _, endpoint := range cfg.RoutingV1Endpoints {
+		rv1Opts := []routingv1client.Option{routingv1client.WithHTTPClient(httpClient)}
+		if endpoint != cidContactEndpoint {
+			rv1Opts = append(rv1Opts, routingv1client.WithStreamResultsRequired())
+		}
+		delegatedRouter, err := delegatedHTTPContentRouter(endpoint, rv1Opts...)
+		if err != nil {
+			return nil, err
+		}
+		delegatedRouters = append(delegatedRouters, delegatedRouter)
+	}
+
+	return delegatedRouters, nil
+}
+
+func setupDHTRouting(ctx context.Context, cfg Config, h host.Host, ds datastore.Batching, dhtRcMgr network.ResourceManager, bwc metrics.Reporter) (routing.Routing, error) {
+	if cfg.DHTRouting == DHTOff {
+		return nil, nil
+	}
+
+	var err error
+
+	var dhtHost host.Host
+	if cfg.DHTSharedHost {
+		dhtHost = h
+	} else {
+		dhtHost, err = libp2p.New(
+			libp2p.NoListenAddrs,
+			libp2p.BandwidthReporter(bwc),
+			libp2p.DefaultTransports,
+			libp2p.DefaultMuxers,
+			libp2p.ResourceManager(dhtRcMgr),
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	standardClient, err := dht.New(ctx, dhtHost,
+		dht.Datastore(ds),
+		dht.BootstrapPeers(dht.GetDefaultBootstrapPeerAddrInfos()...),
+		dht.Mode(dht.ModeClient),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.DHTRouting == DHTStandard {
+		return standardClient, nil
+	}
+
+	if cfg.DHTRouting == DHTAccelerated {
+		fullRTClient, err := fullrt.NewFullRT(dhtHost, dht.DefaultPrefix,
+			fullrt.DHTOption(
+				dht.Validator(record.NamespacedValidator{
+					"pk":   record.PublicKeyValidator{},
+					"ipns": ipns.Validator{KeyBook: h.Peerstore()},
+				}),
+				dht.Datastore(ds),
+				dht.BootstrapPeers(dht.GetDefaultBootstrapPeerAddrInfos()...),
+				dht.BucketSize(20),
+			))
+		if err != nil {
+			return nil, err
+		}
+		return &bundledDHT{
+			standard: standardClient,
+			fullRT:   fullRTClient,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("unknown DHTRouting option: %q", cfg.DHTRouting)
+}
+
+func setupCompositeRouting(delegatedRouters []routing.Routing, dht routing.Routing) routing.Routing {
+	// Default router is no routing at all: can be especially useful during tests.
+	var router routing.Routing
+	router = &routinghelpers.Null{}
+
+	if len(delegatedRouters) == 0 && dht != nil {
+		router = dht
+	} else {
+		var routers []*routinghelpers.ParallelRouter
+
+		if dht != nil {
+			routers = append(routers, &routinghelpers.ParallelRouter{
+				Router:                  dht,
+				ExecuteAfter:            0,
+				DoNotWaitForSearchValue: true,
+				IgnoreError:             false,
+			})
+		}
+
+		for _, routingV1Router := range delegatedRouters {
+			routers = append(routers, &routinghelpers.ParallelRouter{
+				Timeout:                 15 * time.Second,
+				Router:                  routingV1Router,
+				ExecuteAfter:            0,
+				DoNotWaitForSearchValue: true,
+				IgnoreError:             true,
+			})
+		}
+
+		if len(routers) > 0 {
+			router = routinghelpers.NewComposableParallel(routers)
+		}
+	}
+
+	return router
+}
+
+func setupRouting(ctx context.Context, cfg Config, h host.Host, ds datastore.Batching, dhtRcMgr network.ResourceManager, bwc metrics.Reporter, dnsCache *cachedDNS) (routing.ContentRouting, routing.PeerRouting, routing.ValueStore, error) {
+	delegatedRouters, err := setupDelegatedRouting(cfg, dnsCache)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	dhtRouter, err := setupDHTRouting(ctx, cfg, h, ds, dhtRcMgr, bwc)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	router := setupCompositeRouting(delegatedRouters, dhtRouter)
+
+	var (
+		cr routing.ContentRouting = router
+		pr routing.PeerRouting    = router
+		vs routing.ValueStore     = router
+	)
+
+	// If we're using seed peering, we need to run a lighter Amino DHT for the
+	// peering routing. We need to run a separate DHT with the main host if
+	//  the shared host is disabled, or if we're not running any DHT at all.
+	if cfg.SeedPeering && (!cfg.DHTSharedHost || dhtRouter == nil) {
+		pr, err = dht.New(ctx, h,
+			dht.Datastore(ds),
+			dht.BootstrapPeers(dht.GetDefaultBootstrapPeerAddrInfos()...),
+			dht.Mode(dht.ModeClient),
+		)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
+	return cr, pr, vs, nil
+}
+
+type bundledDHT struct {
+	standard *dht.IpfsDHT
+	fullRT   *fullrt.FullRT
+}
+
+func (b *bundledDHT) getDHT() routing.Routing {
+	if b.fullRT.Ready() {
+		return b.fullRT
+	}
+	return b.standard
+}
+
+func (b *bundledDHT) Provide(ctx context.Context, c cid.Cid, brdcst bool) error {
+	return b.getDHT().Provide(ctx, c, brdcst)
+}
+
+func (b *bundledDHT) FindProvidersAsync(ctx context.Context, c cid.Cid, i int) <-chan peer.AddrInfo {
+	return b.getDHT().FindProvidersAsync(ctx, c, i)
+}
+
+func (b *bundledDHT) FindPeer(ctx context.Context, id peer.ID) (peer.AddrInfo, error) {
+	return b.getDHT().FindPeer(ctx, id)
+}
+
+func (b *bundledDHT) PutValue(ctx context.Context, k string, v []byte, option ...routing.Option) error {
+	return b.getDHT().PutValue(ctx, k, v, option...)
+}
+
+func (b *bundledDHT) GetValue(ctx context.Context, s string, option ...routing.Option) ([]byte, error) {
+	return b.getDHT().GetValue(ctx, s, option...)
+}
+
+func (b *bundledDHT) SearchValue(ctx context.Context, s string, option ...routing.Option) (<-chan []byte, error) {
+	return b.getDHT().SearchValue(ctx, s, option...)
+}
+
+func (b *bundledDHT) Bootstrap(ctx context.Context) error {
+	return b.standard.Bootstrap(ctx)
+}
+
+var _ routing.Routing = (*bundledDHT)(nil)
+
+func delegatedHTTPContentRouter(endpoint string, rv1Opts ...routingv1client.Option) (routing.Routing, error) {
+	cli, err := routingv1client.New(
+		endpoint,
+		append([]routingv1client.Option{
+			routingv1client.WithUserAgent(buildVersion()),
+		}, rv1Opts...)...,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	cr := httpcontentrouter.NewContentRoutingClient(
+		cli,
+	)
+
+	err = view.Register(routingv1client.OpenCensusViews...)
+	if err != nil {
+		return nil, fmt.Errorf("registering HTTP delegated routing views: %w", err)
+	}
+
+	return &routinghelpers.Compose{
+		ValueStore:     cr,
+		PeerRouting:    cr,
+		ContentRouting: cr,
+	}, nil
+}


### PR DESCRIPTION
Closes #109. This PR adds seed-based automatic peering. This works by either leveraging the already-running DHT (if DHT is enabled with shared host), or running a parallel DHT with the main host only for peer routing.

I've added tests that you can run on your machine, but disabled on the CI. The time it takes to connect can vary and I thought it could be a bit flaky to run in the CI. In addition, it would maybe pollute the Amino DHT with all ephemeral peers that are created in each test.

Depends on https://github.com/ipfs/rainbow/pull/114.
Closes #27