### PR TITLE
fix: enable holepunching

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -134,7 +134,6 @@ func Setup(ctx context.Context, cfg Config, key crypto.PrivKey, dnsCache *cached
 	}
 
 	opts := []libp2p.Option{
-		libp2p.ListenAddrStrings(cfg.ListenAddrs...),
 		libp2p.NATPortMap(),
 		libp2p.ConnectionManager(cmgr),
 		libp2p.Identity(key),
@@ -142,6 +141,15 @@ func Setup(ctx context.Context, cfg Config, key crypto.PrivKey, dnsCache *cached
 		libp2p.DefaultTransports,
 		libp2p.DefaultMuxers,
 		libp2p.ResourceManager(bitswapRcMgr),
+		libp2p.EnableHolePunching(),
+	}
+
+	if len(cfg.ListenAddrs) == 0 {
+		// Note: because the transports are set above we must also set the listen addresses
+		// We need to set listen addresses in order for hole punching to work
+		opts = append(opts, libp2p.DefaultListenAddrs)
+	} else {
+		opts = append(opts, libp2p.ListenAddrStrings(cfg.ListenAddrs...))
 	}
 
 	if len(cfg.AnnounceAddrs) > 0 {


### PR DESCRIPTION
This adds holepunching support to Rainbow, which we care about for the purposes of Rainbow being able to download data from peers behind NATs. This should've been here before but was overlooked because I thought it was in go-libp2p by default😅.

Some notes:
- In order to do holepunching to fetch data from nodes behind NATs the rainbow node must know its public facing address
- This means talking to other nodes and asking them for your address, or just knowing it by setting a public IP address as the listen address
- So if not set via config it's either situational (e.g. based on if you've made some queries that involve downloading data from publicly reachable peers), or requires a shared-host DHT (which is not great for other reasons like excessive resource consumption)

Trying to get this fixed for ipfs.io / dweb.link at the moment which should have public IPs and therefore be fine (requires confirmation)