### PR TITLE
fix: libp2p identify agent version

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -146,6 +146,7 @@ func Setup(ctx context.Context, cfg Config, key crypto.PrivKey, dnsCache *cached
 		libp2p.NATPortMap(),
 		libp2p.ConnectionManager(cmgr),
 		libp2p.Identity(key),
+		libp2p.UserAgent("rainbow/" + buildVersion()),
 		libp2p.BandwidthReporter(bwc),
 		libp2p.DefaultTransports,
 		libp2p.DefaultMuxers,

--- a/setup.go
+++ b/setup.go
@@ -233,6 +233,7 @@ func Setup(ctx context.Context, cfg Config, key crypto.PrivKey, dnsCache *cached
 					libp2p.BandwidthReporter(bwc),
 					libp2p.DefaultTransports,
 					libp2p.DefaultMuxers,
+					libp2p.UserAgent("rainbow/"+buildVersion()),
 					libp2p.ResourceManager(dhtRcMgr),
 				)
 				if err != nil {


### PR DESCRIPTION
This makes sure `rainbow/v1.0.0` shows up in [libp2p identify protocol's agent version field](https://github.com/libp2p/specs/blob/master/identify/README.md#agentversion).

cc @hacdias keep in mind to include this if we initialize more than one libp2p instance host.