### PR TITLE
fix: disable bitswap provider announcements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- Rainbow no longer provides announcements of blocks via Bitswap. This is not needed to provide blocks to peers with `RAINBOW_PEERING_SHARED_CACHE`.
+
 ### Security
 
 ## [v1.2.0]

--- a/setup.go
+++ b/setup.go
@@ -397,7 +397,6 @@ func setupPeering(cfg Config, h host.Host) error {
 
 func setupBitswap(ctx context.Context, cfg Config, h host.Host, cr routing.ContentRouting, bstore blockstore.Blockstore) *bitswap.Bitswap {
 	var (
-		provideEnabled         bool
 		peerBlockRequestFilter bsserver.PeerBlockRequestFilter
 	)
 	if cfg.PeeringCache && len(cfg.Peering) > 0 {
@@ -406,13 +405,11 @@ func setupBitswap(ctx context.Context, cfg Config, h host.Host, cr routing.Conte
 			peers[a.ID] = struct{}{}
 		}
 
-		provideEnabled = true
 		peerBlockRequestFilter = func(p peer.ID, c cid.Cid) bool {
 			_, ok := peers[p]
 			return ok
 		}
 	} else {
-		provideEnabled = false
 		peerBlockRequestFilter = func(p peer.ID, c cid.Cid) bool {
 			return false
 		}
@@ -433,7 +430,7 @@ func setupBitswap(ctx context.Context, cfg Config, h host.Host, cr routing.Conte
 
 		// ---- Server Options
 		bitswap.WithPeerBlockRequestFilter(peerBlockRequestFilter),
-		bitswap.ProvideEnabled(provideEnabled),
+		bitswap.ProvideEnabled(false),
 	)
 	bn.Start(bswap)
 


### PR DESCRIPTION
When introducing #114, we enabled provider announcements for the Bitswap server when the peering shared cache is enabled. That is not needed, and only adds additional work load to the Rainbow node. Here we disable it (it's true by default).