### PR TITLE
fix: default to bitswap-client-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- Rainbow no longer initializes Bitswap server by default, restoring behavior from v1.0.0.
+
 ### Security
 
 ## [v1.2.1]

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -145,7 +145,7 @@ Default: 100
 ### `RAINBOW_PEERING_SHARED_CACHE`
 
 > [!WARNING]
-> Experimental feature.
+> Experimental feature, will result in increased network I/O due to Bitswap server being run in addition to the lean client.
 
 Enable sharing of local cache to peers safe-listed with `RAINBOW_PEERING`
 or `RAINBOW_SEED_PEERING`.

--- a/main.go
+++ b/main.go
@@ -234,7 +234,7 @@ Generate an identity seed and launch a gateway:
 			Name:    "peering-shared-cache",
 			Value:   false,
 			EnvVars: []string{"RAINBOW_PEERING_SHARED_CACHE"},
-			Usage:   "Enable sharing of local cache to peers safe-listed with --peering. Rainbow will respond to Bitswap queries from these peers, serving locally cached data as needed.",
+			Usage:   "(EXPERIMENTAL: increased network I/O) Enable sharing of local cache to peers safe-listed with --peering. Rainbow will respond to Bitswap queries from these peers, serving locally cached data as needed.",
 		},
 		&cli.StringFlag{
 			Name:    "blockstore",
@@ -360,7 +360,7 @@ share the same seed as long as the indexes are different.
 			IpnsMaxCacheTTL:         cctx.Duration("ipns-max-cache-ttl"),
 			DenylistSubs:            cctx.StringSlice("denylists"),
 			Peering:                 peeringAddrs,
-			PeeringCache:            cctx.Bool("peering-shared-cache"),
+			PeeringSharedCache:      cctx.Bool("peering-shared-cache"),
 			Seed:                    seed,
 			SeedIndex:               index,
 			SeedPeering:             cctx.Bool("seed-peering"),

--- a/setup_bitswap.go
+++ b/setup_bitswap.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/ipfs/boxo/bitswap"
+	bsclient "github.com/ipfs/boxo/bitswap/client"
+	wl "github.com/ipfs/boxo/bitswap/client/wantlist"
+	bsmspb "github.com/ipfs/boxo/bitswap/message/pb"
+	bsnet "github.com/ipfs/boxo/bitswap/network"
+	bsserver "github.com/ipfs/boxo/bitswap/server"
+	"github.com/ipfs/boxo/blockstore"
+	"github.com/ipfs/boxo/exchange"
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	delay "github.com/ipfs/go-ipfs-delay"
+	metri "github.com/ipfs/go-metrics-interface"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/routing"
+)
+
+func setupBitswapExchange(ctx context.Context, cfg Config, h host.Host, cr routing.ContentRouting, bstore blockstore.Blockstore) exchange.Interface {
+	bsctx := metri.CtxScope(ctx, "ipfs_bitswap")
+	bn := bsnet.NewFromIpfsHost(h, cr)
+
+	// --- Client Options
+	// bitswap.RebroadcastDelay: default is 1 minute to search for a random
+	// live-want (1 CID).  I think we want to search for random live-wants more
+	// often although probably it overlaps with general rebroadcasts.
+	rebroadcastDelay := delay.Fixed(10 * time.Second)
+	// bitswap.ProviderSearchDelay: default is 1 second.
+	providerSearchDelay := 1 * time.Second
+
+	// If peering and shared cache are both enabled, we initialize both a
+	// Client and a Server with custom request filter and custom options.
+	// client+server is more expensive but necessary when deployment requires
+	// serving cached blocks to safelisted peerids
+	if cfg.PeeringSharedCache && len(cfg.Peering) > 0 {
+		var peerBlockRequestFilter bsserver.PeerBlockRequestFilter
+
+		// Set up request filter to only respond to request for safelisted (peered) nodes
+		peers := make(map[peer.ID]struct{}, len(cfg.Peering))
+		for _, a := range cfg.Peering {
+			peers[a.ID] = struct{}{}
+		}
+		peerBlockRequestFilter = func(p peer.ID, c cid.Cid) bool {
+			_, ok := peers[p]
+			return ok
+		}
+
+		// Initialize client+server
+		bswap := bitswap.New(bsctx, bn, bstore,
+			// --- Client Options
+			bitswap.RebroadcastDelay(rebroadcastDelay),
+			bitswap.ProviderSearchDelay(providerSearchDelay),
+			bitswap.WithoutDuplicatedBlockStats(),
+
+			// ---- Server Options
+			bitswap.WithPeerBlockRequestFilter(peerBlockRequestFilter),
+			bitswap.ProvideEnabled(false),
+			// Do not keep track of other peer's wantlists, we only want to reply if we
+			// have a block. If we get it later, it's no longer relevant.
+			bitswap.WithPeerLedger(&noopPeerLedger{}),
+			// When we don't have a block, don't reply. This reduces processment.
+			bitswap.SetSendDontHaves(false),
+		)
+		bn.Start(bswap)
+		return &noNotifyExchange{bswap}
+	}
+
+	// By default, rainbow runs with bitswap client alone
+	bswap := bsclient.New(bsctx, bn, bstore,
+		// --- Client Options
+		bsclient.RebroadcastDelay(rebroadcastDelay),
+		bsclient.ProviderSearchDelay(providerSearchDelay),
+		bsclient.WithoutDuplicatedBlockStats(),
+	)
+	bn.Start(bswap)
+	return bswap
+}
+
+type noopPeerLedger struct{}
+
+func (*noopPeerLedger) Wants(p peer.ID, e wl.Entry) {}
+
+func (*noopPeerLedger) CancelWant(p peer.ID, k cid.Cid) bool {
+	return false
+}
+
+func (*noopPeerLedger) CancelWantWithType(p peer.ID, k cid.Cid, typ bsmspb.Message_Wantlist_WantType) {
+}
+
+func (*noopPeerLedger) Peers(k cid.Cid) []bsserver.PeerEntry {
+	return nil
+}
+
+func (*noopPeerLedger) CollectPeerIDs() []peer.ID {
+	return nil
+}
+
+func (*noopPeerLedger) WantlistSizeForPeer(p peer.ID) int {
+	return 0
+}
+
+func (*noopPeerLedger) WantlistForPeer(p peer.ID) []wl.Entry {
+	return nil
+}
+
+func (*noopPeerLedger) ClearPeerWantlist(p peer.ID) {}
+
+func (*noopPeerLedger) PeerDisconnected(p peer.ID) {}
+
+type noNotifyExchange struct {
+	exchange.Interface
+}
+
+func (e *noNotifyExchange) NotifyNewBlocks(ctx context.Context, blocks ...blocks.Block) error {
+	// Rainbow does not notify when we get new blocks in our Blockservice.
+	return nil
+}

--- a/setup_test.go
+++ b/setup_test.go
@@ -83,7 +83,7 @@ func mustPeeredNodes(t *testing.T, configuration [][]int, peeringShareCache bool
 			RoutingV1Endpoints: []string{},
 			ListenAddrs:        []string{mas[i].String()},
 			Peering:            []peer.AddrInfo{},
-			PeeringCache:       peeringShareCache,
+			PeeringSharedCache: peeringShareCache,
 		}
 
 		for _, j := range configuration[i] {
@@ -118,7 +118,7 @@ func TestPeering(t *testing.T) {
 	}, false)
 }
 
-func TestPeeringCache(t *testing.T) {
+func TestPeeringSharedCache(t *testing.T) {
 	nodes := mustPeeredNodes(t, [][]int{
 		{1}, // 0 peered to 1
 		{0}, // 1 peered to 0

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v1.2.1"
+  "version": "v1.2.2"
 }


### PR DESCRIPTION
@aschmahmann as discussed, this restores bitswap setup we had in v1.0.0 where only the client is initialized by default.

If this looks ok, we can ship this as v1.2.2 and deploy to our infra.