### PR TITLE
cli: libp2p listen addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The following emojis are used to highlight certain changes:
 ### Added
 
 - Now supports remote backends (using RAW block or CAR requests) via `--remote-backends` (`RAINBOW_REMOTE_BACKENDS`).
+- Added configurable libp2p listen addresses for the Bitswap host via the `libp2p-listen-addrs` flag and `RAINBOW_LIBP2P_LISTEN_ADDRS` environment variable
 
 ### Changed
 

--- a/main.go
+++ b/main.go
@@ -286,6 +286,17 @@ Generate an identity seed and launch a gateway:
 				}
 			},
 		},
+		&cli.StringSliceFlag{
+			Name: "libp2p-listen-addrs",
+			Value: cli.NewStringSlice("/ip4/0.0.0.0/tcp/4001",
+				"/ip4/0.0.0.0/udp/4001/quic-v1",
+				"/ip4/0.0.0.0/udp/4001/quic-v1/webtransport",
+				"/ip6/::/tcp/4001",
+				"/ip6/::/udp/4001/quic-v1",
+				"/ip6/::/udp/4001/quic-v1/webtransport"),
+			EnvVars: []string{"RAINBOW_LIBP2P_LISTEN_ADDRS"},
+			Usage:   "Multiaddresses for libp2p bitswap client to listen on (comma-separated)",
+		},
 	}
 
 	app.Commands = []*cli.Command{
@@ -429,6 +440,7 @@ share the same seed as long as the indexes are different.
 			RemoteBackendMode:       RemoteBackendMode(cctx.String("remote-backends-mode")),
 			GCInterval:              cctx.Duration("gc-interval"),
 			GCThreshold:             cctx.Float64("gc-threshold"),
+			ListenAddrs:             cctx.StringSlice("libp2p-listen-addrs"),
 		}
 
 		var gnd *Node


### PR DESCRIPTION
This is an updated version of #59 that closes #128 

While we have holepunching support and might not need public listen addresses having them will make things more robust since we can rely on dialback behavior rather than holepunching. While we can listen on the default addresses having configurability here makes it easier for us to enable limited firewall rules.

Note: we could add announce addresses as well if we wanted, at the moment I've left it out to reduce complexity around announce vs append-announce and since I don't have an immediate need for it (e.g. not announcing DNS names). If others want this we could certainly add it though.