### PR TITLE
fix(docker): --version match release git tag

### DIFF
--- a/version.go
+++ b/version.go
@@ -5,9 +5,17 @@ import (
 	"time"
 )
 
-var name = "rainbow"
-var version = buildVersion()
-var userAgent = name + "/" + version
+var (
+	name      = "rainbow"
+	version   string
+	userAgent string
+	gitTag    string
+)
+
+func init() {
+	version = buildVersion()
+	userAgent = name + "/" + version
+}
 
 func buildVersion() string {
 	var revision string
@@ -31,6 +39,12 @@ func buildVersion() string {
 	}
 	if dirty {
 		revision += "-dirty"
+	}
+	if gitTag != "" {
+		if revision != "" {
+			gitTag += "/" + day + "-" + revision
+		}
+		return gitTag
 	}
 	if revision != "" {
 		return day + "-" + revision


### PR DESCRIPTION
This makes `rainbow --version` in docker images be prefixed with the value from release git tag.  Non-Docker and developer builds will have the old value.

### Example

```console
$ docker run --rm -it --net=host rainbow-test-v99 --version
rainbow version v99.0.0/2024-06-11-981f80e

$ docker run --rm -it --net=host rainbow-test-v99-dirty --version
rainbow version v99.0.0/2024-06-11-981f80e-dirty

$ docker run --rm -it --net=host rainbow-test-main-dev-build --version
rainbow version 2024-06-11-1d56b9b
```

Requires below to land first:
- [ ] https://github.com/ipshipyard/waterworks-infra/pull/180


Closes #145