### PR TITLE
fix: --version flag includes release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The following emojis are used to highlight certain changes:
 ### Fixed
 
 - Added more buckets to the duration histogram metric to allow for tracking operations that take longer than 1 minute.
+- Release version included in --version output.
 
 ### Security
 

--- a/version.go
+++ b/version.go
@@ -1,22 +1,33 @@
 package main
 
 import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
 	"runtime/debug"
 	"time"
 )
+
+//go:embed version.json
+var versionJSON []byte
 
 var name = "rainbow"
 var version = buildVersion()
 var userAgent = name + "/" + version
 
 func buildVersion() string {
+	// Read version from embedded JSON file.
+	var verMap map[string]string
+	json.Unmarshal(versionJSON, &verMap)
+	release := verMap["version"]
+
 	var revision string
 	var day string
 	var dirty bool
 
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
-		return "dev-build"
+		return release + " dev-build"
 	}
 	for _, kv := range info.Settings {
 		switch kv.Key {
@@ -33,7 +44,7 @@ func buildVersion() string {
 		revision += "-dirty"
 	}
 	if revision != "" {
-		return day + "-" + revision
+		return fmt.Sprintf("%s %s-%s", release, day, revision)
 	}
-	return "dev-build"
+	return release + " dev-build"
 }


### PR DESCRIPTION
The tagged release version should match the contents of version.json, so embed the version.json file and add the release version from it to the output from `--version`.

Output:
```shell
> docker run --rm -it 3dc6e920ed8d --version
rainbow version v1.3.0 2024-06-18-7d805fd-dirty                               
rainbow version v1.3.0 2024-06-18-7d805fd-dirty
```

Fixes #145