### PR TITLE
Add ability to configure bitswap wanthave replacement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4
 	github.com/ipfs-shipyard/nopfs v0.0.12
 	github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231024163508-120e0c51ee3a
-	github.com/ipfs/boxo v0.23.0
+	github.com/ipfs/boxo v0.23.1-0.20240920171645-1364a16755c3
 	github.com/ipfs/go-block-format v0.2.0
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-datastore v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231024163508-120e0c51ee3a h1:MKG
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231024163508-120e0c51ee3a/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.23.0 h1:dY1PpcvPJ//VuUQ1TUd5TZvmaGuzxJ8dOP6mXaw+ke8=
-github.com/ipfs/boxo v0.23.0/go.mod h1:ulu5I6avTmgGmvjuCaBRKwsaOOKjBfQw1EiOOQp8M6E=
+github.com/ipfs/boxo v0.23.1-0.20240920171645-1364a16755c3 h1:STC1B6+L6toikFAHKCFvEheaWu9U+gPn1EuP3WnFfBw=
+github.com/ipfs/boxo v0.23.1-0.20240920171645-1364a16755c3/go.mod h1:ulu5I6avTmgGmvjuCaBRKwsaOOKjBfQw1EiOOQp8M6E=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/main.go
+++ b/main.go
@@ -260,6 +260,12 @@ Generate an identity seed and launch a gateway:
 			EnvVars: []string{"RAINBOW_BITSWAP"},
 			Usage:   "Controls if Bitswap is enabled (useful for testing or when remote backend is used instead)",
 		},
+		&cli.IntFlag{
+			Name:    "bitswap-wanthave-replace-size",
+			Value:   1024,
+			EnvVars: []string{"BITSWAP_WANTHAVE_REPLACE_SIZE"},
+			Usage:   "Replace WantHave requests with WantBlock for small blocks up to this size, zero to disable",
+		},
 		&cli.StringSliceFlag{
 			Name:    "remote-backends",
 			Value:   cli.NewStringSlice(),
@@ -439,6 +445,7 @@ share the same seed as long as the indexes are different.
 			DHTRouting:              dhtRouting,
 			DHTSharedHost:           cctx.Bool("dht-shared-host"),
 			Bitswap:                 bitswap,
+			BitswapHaveReplaceSize:  cctx.Int("bitswap-wanthave-replace-size"),
 			IpnsMaxCacheTTL:         cctx.Duration("ipns-max-cache-ttl"),
 			DenylistSubs:            cctx.StringSlice("denylists"),
 			Peering:                 peeringAddrs,

--- a/setup.go
+++ b/setup.go
@@ -107,6 +107,11 @@ type Config struct {
 	IpnsMaxCacheTTL         time.Duration
 	Bitswap                 bool
 
+	// BitswapHaveReplaceSize tells the bitswap server to replace WantHave
+	// with WantBlock requests when the block size less then or equal to this
+	// value. Set to zero to disable replacement and avoid block size lookup.
+	BitswapHaveReplaceSize int
+
 	DenylistSubs []string
 
 	Peering            []peer.AddrInfo

--- a/setup_bitswap.go
+++ b/setup_bitswap.go
@@ -60,6 +60,7 @@ func setupBitswapExchange(ctx context.Context, cfg Config, h host.Host, cr routi
 			bitswap.ProvideEnabled(false),
 			// When we don't have a block, don't reply. This reduces processment.
 			bitswap.SetSendDontHaves(false),
+			bitswap.WithReplaceHasWithBlockMaxSize(cfg.BitswapHaveReplaceSize),
 		)
 		bn.Start(bswap)
 		return &noNotifyExchange{bswap}


### PR DESCRIPTION
A new flag and environ var is available to specify the maximum blocksize that bitswap will replace WantHave with WantBlock responses. A value of zero diables replacement and avoids block size lookup for WantHave requests. This option only applies when bitswap is enabled.

Depends on: https://github.com/ipfs/boxo/pull/672
