### PR TITLE
feat(http-routers): filter-protocols from IPIP-484

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ The following emojis are used to highlight certain changes:
 ## [Unreleased]
 
 ### Added
-- Ability to specify the maximum blocksize that bitswap will replace WantHave with WantBlock responses, and to disable replacement when set to zero. [#165](https://github.com/ipfs/rainbow/pull/165)
-- Support use and configuration of pebble as [datastore](https://github.com/ipfs/rainbow/blob/main/docs/blockstores.md). Pebble provides a high-performance alternative to badger. Options are available to configure key tuning parameters (`pebble-*` in `rainbow --help`). 
+
+- Support implicit default list for `filter-protocols` from [IPIP-484](https://github.com/ipfs/specs/pull/484) and customizing them via `--http-routers-filter-protocols`.
 
 ### Changed
 
@@ -24,6 +24,13 @@ The following emojis are used to highlight certain changes:
 ### Fixed
 
 ### Security
+
+## [v1.7.0]
+
+### Added
+
+- Ability to specify the maximum blocksize that bitswap will replace WantHave with WantBlock responses, and to disable replacement when set to zero. [#165](https://github.com/ipfs/rainbow/pull/165)
+- Support use and configuration of pebble as [datastore](https://github.com/ipfs/rainbow/blob/main/docs/blockstores.md). Pebble provides a high-performance alternative to badger. Options are available to configure key tuning parameters (`pebble-*` in `rainbow --help`).
 
 ## [v1.6.0]
 

--- a/main.go
+++ b/main.go
@@ -204,6 +204,12 @@ Generate an identity seed and launch a gateway:
 			EnvVars: []string{"RAINBOW_HTTP_ROUTERS"},
 			Usage:   "HTTP servers with /routing/v1 endpoints to use for delegated routing (comma-separated)",
 		},
+		&cli.StringSliceFlag{
+			Name:    "http-routers-filter-protocols",
+			Value:   cli.NewStringSlice(httpRoutersFilterProtocols...),
+			EnvVars: []string{"RAINBOW_HTTP_ROUTERS_FILTER_PROTOCOLS"},
+			Usage:   "IPIP-484 filter-protocols to apply to delegated routing requests (comma-separated)",
+		},
 		&cli.StringFlag{
 			Name:    "dht-routing",
 			Value:   "accelerated",
@@ -502,6 +508,7 @@ share the same seed as long as the indexes are different.
 			MaxFD:                      cctx.Int("libp2p-max-fd"),
 			InMemBlockCache:            cctx.Int64("inmem-block-cache"),
 			RoutingV1Endpoints:         cctx.StringSlice("http-routers"),
+			RoutingV1FilterProtocols:   cctx.StringSlice("http-routers-filter-protocols"),
 			DHTRouting:                 dhtRouting,
 			DHTSharedHost:              cctx.Bool("dht-shared-host"),
 			Bitswap:                    bitswap,

--- a/setup.go
+++ b/setup.go
@@ -51,6 +51,8 @@ func init() {
 
 const cidContactEndpoint = "https://cid.contact"
 
+var httpRoutersFilterProtocols = []string{"unknown", "transport-bitswap"} // IPIP-484
+
 type DHTRouting string
 
 const (
@@ -100,14 +102,15 @@ type Config struct {
 	MaxMemory       uint64
 	MaxFD           int
 
-	GatewayDomains          []string
-	SubdomainGatewayDomains []string
-	TrustlessGatewayDomains []string
-	RoutingV1Endpoints      []string
-	DHTRouting              DHTRouting
-	DHTSharedHost           bool
-	IpnsMaxCacheTTL         time.Duration
-	Bitswap                 bool
+	GatewayDomains           []string
+	SubdomainGatewayDomains  []string
+	TrustlessGatewayDomains  []string
+	RoutingV1Endpoints       []string
+	RoutingV1FilterProtocols []string
+	DHTRouting               DHTRouting
+	DHTSharedHost            bool
+	IpnsMaxCacheTTL          time.Duration
+	Bitswap                  bool
 
 	// BitswapWantHaveReplaceSize tells the bitswap server to replace WantHave
 	// with WantBlock responses when the block size less then or equal to this


### PR DESCRIPTION
This is Rainbow version of https://github.com/ipfs/kubo/pull/10534 which adds support for `filter-protocols` from [IPIP-484](https://github.com/ipfs/specs/pull/484) and makes Rainbow use `unknown` + `transport-bitswap` as implicit default.

The intention here is to skip peers which are not actionable.