### PR TITLE
Error instead of dropping unauthorized headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The following emojis are used to highlight certain changes:
 
 - boxo [v0.24.3](https://github.com/ipfs/boxo/releases/tag/v0.24.3)
 - go-libp2p-kad-dht [v0.28.1](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.28.1)
+- passing headers that require authorization but are not authorized now results in an HTTP 401 instead of ignoring those headers
 
 ### Removed
 

--- a/docs/headers.md
+++ b/docs/headers.md
@@ -8,7 +8,7 @@ See [`RAINBOW_TRACING_AUTH`](./environment-variables.md#rainbow_tracing_auth)
 
 Optional. Clients may use this header to return a additional vendor-specific trace identification information across different distributed tracing systems.
 
-Currently ignored unless `Authorization` matches [`RAINBOW_TRACING_AUTH`](./environment-variables.md#rainbow_tracing_auth).
+Will error unless `Authorization` matches [`RAINBOW_TRACING_AUTH`](./environment-variables.md#rainbow_tracing_auth).
 
 > [!TIP]
 > `Traceparent` value format can be found in [W3C Trace Context Specification](https://www.w3.org/TR/trace-context-1/#trace-context-http-headers-format).
@@ -19,7 +19,7 @@ Currently ignored unless `Authorization` matches [`RAINBOW_TRACING_AUTH`](./envi
 
 Optional. Clients may use this header to return a additional vendor-specific trace identification information in addition to `Traceparent`.
 
-Currently ignored unless `Authorization` matches [`RAINBOW_TRACING_AUTH`](./environment-variables.md#rainbow_tracing_auth).
+Will error unless `Authorization` matches [`RAINBOW_TRACING_AUTH`](./environment-variables.md#rainbow_tracing_auth).
 
 > [!TIP]
 > `Tracestate` value format can be found in [W3C Trace Context Specification](https://www.w3.org/TR/trace-context-1/#trace-context-http-headers-format).
@@ -28,6 +28,6 @@ Currently ignored unless `Authorization` matches [`RAINBOW_TRACING_AUTH`](./envi
 
 If the value is `true` the associated request will skip the local block cache and leverage a separate in-memory block cache for the request.
 
-This header is not respected unless the request has a valid `Authorization` header
+Will error unless the request has a valid `Authorization` header
 
 See [`RAINBOW_TRACING_AUTH`](./environment-variables.md#rainbow_tracing_auth)

--- a/handler_test.go
+++ b/handler_test.go
@@ -158,15 +158,12 @@ func TestNoBlockcacheHeader(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, url, nil)
 		require.NoError(t, err)
 
-		// Authorization missing, expect NoBlockcacheHeader to be ignored
+		// Authorization missing, expect NoBlockcacheHeader to result in an error
 		req.Header.Set(NoBlockcacheHeader, "true")
 
 		res, err := http.DefaultClient.Do(req)
 		assert.NoError(t, err)
-		assert.Equal(t, http.StatusOK, res.StatusCode)
-		responseBody, err := io.ReadAll(res.Body)
-		assert.NoError(t, err)
-		assert.Equal(t, content, responseBody)
+		assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
 	})
 
 	t.Run("Skipping the cache only works when RAINBOW_TRACING_AUTH is set", func(t *testing.T) {
@@ -185,14 +182,11 @@ func TestNoBlockcacheHeader(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, url, nil)
 		require.NoError(t, err)
 
-		// Authorization missing, expect NoBlockcacheHeader to be ignored
+		// Authorization missing, expect NoBlockcacheHeader to result in an error
 		req.Header.Set(NoBlockcacheHeader, "true")
 
 		res, err := http.DefaultClient.Do(req)
 		assert.NoError(t, err)
-		assert.Equal(t, http.StatusOK, res.StatusCode)
-		responseBody, err := io.ReadAll(res.Body)
-		assert.NoError(t, err)
-		assert.Equal(t, content, responseBody)
+		assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
 	})
 }

--- a/handlers.go
+++ b/handlers.go
@@ -363,14 +363,10 @@ func withTracingAndDebug(next http.Handler, authToken string) http.Handler {
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		// Disable tracing/debug headers if auth token missing or invalid
 		if authToken == "" || request.Header.Get("Authorization") != authToken {
-			if request.Header.Get("Traceparent") != "" {
-				request.Header.Del("Traceparent")
-			}
-			if request.Header.Get("Tracestate") != "" {
-				request.Header.Del("Tracestate")
-			}
-			if request.Header.Get(NoBlockcacheHeader) != "" {
-				request.Header.Del(NoBlockcacheHeader)
+			if request.Header.Get("Traceparent") != "" || request.Header.Get("Tracestate") != "" || request.Header.Get(NoBlockcacheHeader) != "" {
+				writer.WriteHeader(http.StatusUnauthorized)
+				_, _ = writer.Write([]byte("The request is not accompanied by a valid authorization header"))
+				return
 			}
 		}
 

--- a/handlers.go
+++ b/handlers.go
@@ -364,8 +364,7 @@ func withTracingAndDebug(next http.Handler, authToken string) http.Handler {
 		// Disable tracing/debug headers if auth token missing or invalid
 		if authToken == "" || request.Header.Get("Authorization") != authToken {
 			if request.Header.Get("Traceparent") != "" || request.Header.Get("Tracestate") != "" || request.Header.Get(NoBlockcacheHeader) != "" {
-				writer.WriteHeader(http.StatusUnauthorized)
-				_, _ = writer.Write([]byte("The request is not accompanied by a valid authorization header"))
+				http.Error(writer, "The request is not accompanied by a valid authorization header", http.StatusUnauthorized)
 				return
 			}
 		}


### PR DESCRIPTION
We previously just didn't honor headers that required authorization but didn't provide it, this errors making things more explicit and less error prone. @gammazero just ran into some confusion here and it seems like being more explicit here could be helpful.

WDYT @lidel?
