### PR TITLE
feat: add flags to configure bitswap tuning params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The following emojis are used to highlight certain changes:
 ### Added
 
 - Added endpoints to show and purge connected peers [#194](https://github.com/ipfs/rainbow/pull/194)
+- Added flags to configure bitswap tuning params:
+  - `bitswap-max-concurrent-finds`
+  - `bitswap-max-providers-per-find`
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4
 	github.com/ipfs-shipyard/nopfs v0.0.12
 	github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231024163508-120e0c51ee3a
-	github.com/ipfs/boxo v0.24.4-0.20241122211943-31d3e4d81004
+	github.com/ipfs/boxo v0.24.4-0.20241122213905-f6d672a073dc
 	github.com/ipfs/go-block-format v0.2.0
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-datastore v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4
 	github.com/ipfs-shipyard/nopfs v0.0.12
 	github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231024163508-120e0c51ee3a
-	github.com/ipfs/boxo v0.24.4-0.20241122213905-f6d672a073dc
+	github.com/ipfs/boxo v0.24.4-0.20241122225644-7409ebea25a2
 	github.com/ipfs/go-block-format v0.2.0
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-datastore v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4
 	github.com/ipfs-shipyard/nopfs v0.0.12
 	github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231024163508-120e0c51ee3a
-	github.com/ipfs/boxo v0.24.3
+	github.com/ipfs/boxo v0.24.4-0.20241122211943-31d3e4d81004
 	github.com/ipfs/go-block-format v0.2.0
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-datastore v0.6.0
@@ -78,6 +78,8 @@ require (
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.6 // indirect
+	github.com/gammazero/channelqueue v0.2.2 // indirect
+	github.com/gammazero/deque v1.0.0 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4
 	github.com/ipfs-shipyard/nopfs v0.0.12
 	github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231024163508-120e0c51ee3a
-	github.com/ipfs/boxo v0.24.4-0.20241122225644-7409ebea25a2
+	github.com/ipfs/boxo v0.24.4-0.20241123075419-9326f0a83585
 	github.com/ipfs/go-block-format v0.2.0
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-datastore v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231024163508-120e0c51ee3a h1:MKG
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231024163508-120e0c51ee3a/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241122211943-31d3e4d81004 h1:W+qmDx3L5e1MJY6RHALOMvdrCdqm/0nClgeXvgKiUzY=
-github.com/ipfs/boxo v0.24.4-0.20241122211943-31d3e4d81004/go.mod h1:mBC/110NmitZRaEOyp1l/VBWj9guCzNVlg4uuWR7ZfA=
+github.com/ipfs/boxo v0.24.4-0.20241122213905-f6d672a073dc h1:nEIKTi3bW7HbO7VX0KAF82K1rm6mmHPD6BxppZCYTKE=
+github.com/ipfs/boxo v0.24.4-0.20241122213905-f6d672a073dc/go.mod h1:DbXsp9GnF9cL4wDurnFnh2SSGjUcuiZmkhAcCA63J5A=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=
@@ -662,6 +662,8 @@ github.com/shurcooL/users v0.0.0-20180125191416-49c67e49c537/go.mod h1:QJTqeLYED
 github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5kWdCj2z2KEozexVbfEZIWiTjhE0+UjmZgPqehw=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/slok/go-http-metrics v0.12.0 h1:mAb7hrX4gB4ItU6NkFoKYdBslafg3o60/HbGBRsKaG8=
+github.com/slok/go-http-metrics v0.12.0/go.mod h1:Ee/mdT9BYvGrlGzlClkK05pP2hRHmVbRF9dtUVS8LNA=
 github.com/smartystreets/assertions v1.2.0 h1:42S6lae5dvLc7BrLu/0ugRtcFVjoJNMC/N3yZFZkDFs=
 github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hgR6gDIPg=

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231024163508-120e0c51ee3a h1:MKG
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231024163508-120e0c51ee3a/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241122225644-7409ebea25a2 h1:P5/hA+/9ymER5xKlF4DVruntJaW2PGKMir1d6xfpHwA=
-github.com/ipfs/boxo v0.24.4-0.20241122225644-7409ebea25a2/go.mod h1:DbXsp9GnF9cL4wDurnFnh2SSGjUcuiZmkhAcCA63J5A=
+github.com/ipfs/boxo v0.24.4-0.20241123075419-9326f0a83585 h1:oIoarFLOfCJprj6JYHuoEc9q1E4rAHoflkx4Hs38Tsc=
+github.com/ipfs/boxo v0.24.4-0.20241123075419-9326f0a83585/go.mod h1:DbXsp9GnF9cL4wDurnFnh2SSGjUcuiZmkhAcCA63J5A=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231024163508-120e0c51ee3a h1:MKG
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231024163508-120e0c51ee3a/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241122213905-f6d672a073dc h1:nEIKTi3bW7HbO7VX0KAF82K1rm6mmHPD6BxppZCYTKE=
-github.com/ipfs/boxo v0.24.4-0.20241122213905-f6d672a073dc/go.mod h1:DbXsp9GnF9cL4wDurnFnh2SSGjUcuiZmkhAcCA63J5A=
+github.com/ipfs/boxo v0.24.4-0.20241122225644-7409ebea25a2 h1:P5/hA+/9ymER5xKlF4DVruntJaW2PGKMir1d6xfpHwA=
+github.com/ipfs/boxo v0.24.4-0.20241122225644-7409ebea25a2/go.mod h1:DbXsp9GnF9cL4wDurnFnh2SSGjUcuiZmkhAcCA63J5A=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,10 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gabriel-vasile/mimetype v1.4.6 h1:3+PzJTKLkvgjeTbts6msPJt4DixhT4YtFNf1gtGe3zc=
 github.com/gabriel-vasile/mimetype v1.4.6/go.mod h1:JX1qVKqZd40hUPpAfiNTe0Sne7hdfKSbOqqmkq8GCXc=
+github.com/gammazero/channelqueue v0.2.2 h1:ufNzIbeDBxNfHj0m5uwUfOwvTmHF/O40hu2ZNnvF+/8=
+github.com/gammazero/channelqueue v0.2.2/go.mod h1:824o5HHE+yO1xokh36BIuSv8YWwXW0364ku91eRMFS4=
+github.com/gammazero/deque v1.0.0 h1:LTmimT8H7bXkkCy6gZX7zNLtkbz4NdS2z8LZuor3j34=
+github.com/gammazero/deque v1.0.0/go.mod h1:iflpYvtGfM3U8S8j+sZEKIak3SAKYpA5/SQewgfXDKo=
 github.com/garyburd/redigo v1.1.1-0.20170914051019-70e1b1943d4f/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
 github.com/getsentry/sentry-go v0.27.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
@@ -256,8 +260,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231024163508-120e0c51ee3a h1:MKG
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231024163508-120e0c51ee3a/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.3 h1:gldDPOWdM3Rz0v5LkVLtZu7A7gFNvAlWcmxhCqlHR3c=
-github.com/ipfs/boxo v0.24.3/go.mod h1:h0DRzOY1IBFDHp6KNvrJLMFdSXTYID0Zf+q7X05JsNg=
+github.com/ipfs/boxo v0.24.4-0.20241122211943-31d3e4d81004 h1:W+qmDx3L5e1MJY6RHALOMvdrCdqm/0nClgeXvgKiUzY=
+github.com/ipfs/boxo v0.24.4-0.20241122211943-31d3e4d81004/go.mod h1:mBC/110NmitZRaEOyp1l/VBWj9guCzNVlg4uuWR7ZfA=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/main.go
+++ b/main.go
@@ -381,17 +381,23 @@ Generate an identity seed and launch a gateway:
 			EnvVars: []string{"PEBBLE_WAL_MIN_SYNC_INTERVAL"},
 			Usage:   "Sets the minimum duration between syncs of the WAL",
 		},
+		&cli.DurationFlag{
+			Name:    "bitswap-find-provider-timeout",
+			Value:   10 * time.Second,
+			EnvVars: []string{"BITSWAP_FIND_PROVIDER_TIMEOUT"},
+			Usage:   "Maximum time to spend on an attempt to find providers. 0 for bitswap default",
+		},
 		&cli.IntFlag{
 			Name:    "bitswap-max-concurrent-finds",
-			Value:   0,
+			Value:   16,
 			EnvVars: []string{"BITSWAP_MAX_CONCURRENT_FINDS"},
-			Usage:   "Maximum number of concurrent bitswap finds. Set 0 for bitswap default.",
+			Usage:   "Maximum number of concurrent bitswap finds. 0 for bitswap default.",
 		},
 		&cli.IntFlag{
 			Name:    "bitswap-max-providers-per-find",
 			EnvVars: []string{"BITSWAP_MAX_PROVIDERS_PER_FIND"},
-			Value:   0,
-			Usage:   "Maximum number of providers to return for each bitswap find. Set 0 for bitswap default.",
+			Value:   10,
+			Usage:   "Maximum number of providers to return for each bitswap find. 0 for bitswap default.",
 		},
 	}
 
@@ -554,6 +560,7 @@ share the same seed as long as the indexes are different.
 			WALMinSyncInterval:          time.Second * time.Duration(cctx.Int("pebble-wal-min-sync-interval-sec")),
 
 			// Bitswap ProviderQueryManager config
+			bitswapFindProviderTimeout: cctx.Duration("bitswap-find-provider-timeout"),
 			bitswapMaxConcurrentFinds:  cctx.Int("bitswap-max-concurrent-finds"),
 			bitswapMaxProvidersPerFind: cctx.Int("bitswap-max-providers-per-find"),
 		}

--- a/main.go
+++ b/main.go
@@ -381,6 +381,18 @@ Generate an identity seed and launch a gateway:
 			EnvVars: []string{"PEBBLE_WAL_MIN_SYNC_INTERVAL"},
 			Usage:   "Sets the minimum duration between syncs of the WAL",
 		},
+		&cli.IntFlag{
+			Name:    "bitswap-max-concurrent-finds",
+			Value:   0,
+			EnvVars: []string{"BITSWAP_MAX_CONCURRENT_FINDS"},
+			Usage:   "Maximum number of concurrent bitswap finds. Set 0 for bitswap default.",
+		},
+		&cli.IntFlag{
+			Name:    "bitswap-max-providers-per-find",
+			EnvVars: []string{"BITSWAP_MAX_PROVIDERS_PER_FIND"},
+			Value:   0,
+			Usage:   "Maximum number of providers to return for each bitswap find. Set 0 for bitswap default.",
+		},
 	}
 
 	app.Commands = []*cli.Command{
@@ -540,6 +552,10 @@ share the same seed as long as the indexes are different.
 			WALBytesPerSync:             cctx.Int("pebble-wal-Bytes-per-sync"),
 			MaxConcurrentCompactions:    cctx.Int("pebble-max-concurrent-compactions"),
 			WALMinSyncInterval:          time.Second * time.Duration(cctx.Int("pebble-wal-min-sync-interval-sec")),
+
+			// Bitswap ProviderQueryManager config
+			bitswapMaxConcurrentFinds:  cctx.Int("bitswap-max-concurrent-finds"),
+			bitswapMaxProvidersPerFind: cctx.Int("bitswap-max-providers-per-find"),
 		}
 		var gnd *Node
 

--- a/setup.go
+++ b/setup.go
@@ -152,6 +152,7 @@ type Config struct {
 	WALMinSyncInterval          time.Duration
 
 	// Bitswap ProviderQueryManager config
+	bitswapFindProviderTimeout time.Duration
 	bitswapMaxConcurrentFinds  int
 	bitswapMaxProvidersPerFind int
 }

--- a/setup.go
+++ b/setup.go
@@ -150,6 +150,10 @@ type Config struct {
 	WALBytesPerSync             int
 	MaxConcurrentCompactions    int
 	WALMinSyncInterval          time.Duration
+
+	// Bitswap ProviderQueryManager config
+	bitswapMaxConcurrentFinds  int
+	bitswapMaxProvidersPerFind int
 }
 
 func SetupNoLibp2p(ctx context.Context, cfg Config, dnsCache *cachedDNS) (*Node, error) {

--- a/setup_bitswap.go
+++ b/setup_bitswap.go
@@ -72,6 +72,7 @@ func setupBitswapExchange(ctx context.Context, cfg Config, h host.Host, cr routi
 		bsclient.RebroadcastDelay(rebroadcastDelay),
 		bsclient.ProviderSearchDelay(providerSearchDelay),
 		bsclient.WithoutDuplicatedBlockStats(),
+		bsclient.WithFindProviderTimeout(cfg.bitswapFindProviderTimeout),
 		bsclient.WithMaxConcurrentFinds(cfg.bitswapMaxConcurrentFinds),
 		bsclient.WithMaxProvidersPerFind(cfg.bitswapMaxProvidersPerFind),
 	)

--- a/setup_bitswap.go
+++ b/setup_bitswap.go
@@ -72,6 +72,8 @@ func setupBitswapExchange(ctx context.Context, cfg Config, h host.Host, cr routi
 		bsclient.RebroadcastDelay(rebroadcastDelay),
 		bsclient.ProviderSearchDelay(providerSearchDelay),
 		bsclient.WithoutDuplicatedBlockStats(),
+		bsclient.WithMaxConcurrentFinds(cfg.bitswapMaxConcurrentFinds),
+		bsclient.WithMaxProvidersPerFind(cfg.bitswapMaxProvidersPerFind),
 	)
 	bn.Start(bswap)
 	return bswap


### PR DESCRIPTION
Allow configuration of bitswap tuning params.

New CLI flags:
- `bitswap-find-provider-timeout`
- `bitswap-max-concurrent-finds`
- `bitswap-max-providers-per-find`

New environ vars:
- `BITSWAP_FIND_PROVIDER_TIMEOUT`
- `BITSWAP_MAX_CONCURRENT_FINDS`
- `BITSWAP_MAX_PROVIDERS_PER_FIND`

When not set, or set to 0, the bitswap default values are used.

Requires [boxo PR 716](https://github.com/ipfs/boxo/pull/716) 