### PR TITLE
fix: update default DNSLink resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The following emojis are used to highlight certain changes:
 
 ### Changed
 
+- The default DNSLink resolver for `.eth` TLD changed to `https://dns.eth.limo/dns-query` and  `.crypto` one changed to `https://resolver.unstoppable.io/dns-query` [#231](https://github.com/ipfs/rainbow/pull/231)
+
 ### Fixed
 
 ### Removed

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -156,7 +156,7 @@ DNS-over-HTTPS servers to use for resolving DNSLink on specified TLDs (comma-sep
 
 It is possible to override OS resolver by passing root:  `. : catch-URL`.
 
-Default: `eth. : https://resolver.cloudflare-eth.com/dns-query, crypto. : https://resolver.cloudflare-eth.com/dns-query`
+Default: `eth. : https://dns.eth.limo/dns-query, crypto. : https://resolver.unstoppable.io/dns-query`
 
 ## Experiments
 

--- a/setup.go
+++ b/setup.go
@@ -55,8 +55,8 @@ const cidContactEndpoint = "https://cid.contact"
 var httpRoutersFilterProtocols = []string{"unknown", "transport-bitswap"} // IPIP-484
 
 var extraDNSLinkResolvers = []string{
-	"eth. : https://resolver.cloudflare-eth.com/dns-query",
-	"crypto. : https://resolver.cloudflare-eth.com/dns-query",
+	"eth. : https://dns.eth.limo/dns-query",
+	"crypto. : https://resolver.unstoppable.io/dns-query",
 }
 
 type DHTRouting string


### PR DESCRIPTION
This is rainbow version of https://github.com/ipfs/kubo/pull/10655, because Rainbow has own defaults

TLDR reason:
https://github.com/ipfs/boxo/issues/771#issuecomment-2573189494

> Ref. https://developers.cloudflare.com/fundamentals/api/reference/deprecations/#2025-07-01:
> ![image](https://github.com/user-attachments/assets/4171a1f0-6918-4b7e-9496-233c2aded13d)