### PR TITLE
fix: set User-Agent for HTTP retrieval client

### DIFF
--- a/setup_bitswap.go
+++ b/setup_bitswap.go
@@ -34,6 +34,7 @@ func setupBitswapExchange(ctx context.Context, cfg Config, h host.Host, cr routi
 			httpnet.WithHTTPWorkers(cfg.HTTPRetrievalWorkers),
 			httpnet.WithAllowlist(cfg.HTTPRetrievalAllowlist),
 			httpnet.WithDenylist(cfg.HTTPRetrievalDenylist),
+			httpnet.WithUserAgent("rainbow/"+buildVersion()),
 		)
 		exnet = network.New(h.Peerstore(), bn, htnet)
 	} else {


### PR DESCRIPTION
Setting to the same value we already use for libp2p:

https://github.com/ipfs/rainbow/blob/1bf59f710821432bbb28c5ffe98d4028087e5c7e/setup_routing.go#L82

This makes is easier to track which specific rainbow build/release is responsible for requests.
We need this, because Kubo and Rainbow may use the same boxo, but initialize client with slightly different config (Ref. https://github.com/ipfs/kubo/pull/10772)