### PR TITLE
Reset PeriodicGC interval only after it has completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The following emojis are used to highlight certain changes:
   performed. This is a footgun, therefore from now on this is interpreted as
   no allowlist being set. HTTP Retrieval can be disabled with
   `RAINBOW_HTTP_RETRIEVAL_ENABLE=false`.
+- Fix periodicGC that runs before the previous run has finished if the
+  interval is too short.
 
 ### Removed
 

--- a/main.go
+++ b/main.go
@@ -752,11 +752,11 @@ share the same seed as long as the indexes are different.
 			}
 		}()
 
-		var gcTicker *time.Ticker
+		var gcTicker *time.Timer
 		var gcTickerDone chan bool
 
 		if cfg.GCInterval > 0 {
-			gcTicker = time.NewTicker(cfg.GCInterval)
+			gcTicker = time.NewTimer(cfg.GCInterval)
 			gcTickerDone = make(chan bool)
 			wg.Add(1)
 
@@ -772,6 +772,7 @@ share the same seed as long as the indexes are different.
 						if err != nil {
 							goLog.Errorf("error when running periodic gc: %w", err)
 						}
+						gcTicker.Reset(cfg.GCInterval)
 					}
 				}
 			}()


### PR DESCRIPTION
Currently, if a GC operation takes longer than the interval, the code will pile up more gc operations on top.