### PR TITLE
Always upgrade pebble data format to latest

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -608,6 +608,7 @@ func getPebbleOpts(cfg Config) *pebble.Options {
 	opts := &pebble.Options{
 		BytesPerSync:                cfg.BytesPerSync,
 		DisableWAL:                  cfg.DisableWAL,
+		FormatMajorVersion:          pebble.FormatNewest,
 		L0CompactionThreshold:       cfg.L0CompactionThreshold,
 		L0StopWritesThreshold:       cfg.L0StopWritesThreshold,
 		LBaseMaxBytes:               cfg.LBaseMaxBytes,


### PR DESCRIPTION
This ensures that:
- You get all the latest features and improvements offered by the latest data format
- The next pebble update is compatible with, and can upgrade, you data format