### PR TITLE
feat: add dnslink-gateway-domains configuration for DNSLink safelist

### DIFF
--- a/main.go
+++ b/main.go
@@ -486,6 +486,12 @@ Generate an identity seed and launch a gateway:
 			EnvVars: []string{"RAINBOW_DNSLINK_RESOLVERS"},
 			Usage:   "The DNSLink resolvers to use (comma-separated tuples that each look like `eth. : https://dns.eth.limo/dns-query`). Use 'auto' as value to use network-appropriate defaults from autoconf",
 		},
+		&cli.StringSliceFlag{
+			Name:    "dnslink-gateway-domains",
+			Value:   cli.NewStringSlice(),
+			EnvVars: []string{"RAINBOW_DNSLINK_GATEWAY_DOMAINS"},
+			Usage:   "Domains allowed for DNSLink resolution via Host header (comma-separated)",
+        },
 	}
 
 	app.Commands = []*cli.Command{
@@ -649,6 +655,7 @@ share the same seed as long as the indexes are different.
 			GatewayDomains:             cctx.StringSlice("gateway-domains"),
 			SubdomainGatewayDomains:    cctx.StringSlice("subdomain-gateway-domains"),
 			TrustlessGatewayDomains:    cctx.StringSlice("trustless-gateway-domains"),
+			DNSLinkGatewayDomains:      cctx.StringSlice("dnslink-gateway-domains"),
 			ConnMgrLow:                 cctx.Int("libp2p-connmgr-low"),
 			ConnMgrHi:                  cctx.Int("libp2p-connmgr-high"),
 			ConnMgrGrace:               cctx.Duration("libp2p-connmgr-grace"),
@@ -873,6 +880,7 @@ share the same seed as long as the indexes are different.
 		printAutoconfAwareConfig("RAINBOW_DNSLINK_RESOLVERS", originalDNSResolvers, customDNSResolvers, cfg.AutoConf.Enabled)
 		printIfListConfigured(fmt.Sprintf("  %-40s = ", "RAINBOW_REMOTE_BACKENDS"), cfg.RemoteBackends)
 		printAutoconfAwareConfig("RAINBOW_BOOTSTRAP", originalBootstrap, cfg.Bootstrap, cfg.AutoConf.Enabled)
+		printIfListConfigured(fmt.Sprintf("  %-40s = ", "RAINBOW_DNSLINK_GATEWAY_DOMAINS"), cfg.DNSLinkGatewayDomains)
 
 		fmt.Printf("\n")
 		fmt.Printf("CTL endpoint listening at http://%s\n", ctlListen)

--- a/setup.go
+++ b/setup.go
@@ -106,6 +106,7 @@ type Config struct {
 	GatewayDomains           []string
 	SubdomainGatewayDomains  []string
 	TrustlessGatewayDomains  []string
+	DNSLinkGatewayDomains    []string
 	RoutingV1Endpoints       []string
 	RoutingV1FilterProtocols []string
 	RoutingIgnoreProviders   []peer.ID


### PR DESCRIPTION
Fixes #258 

## Description
Adds a new configuration option `--dnslink-gateway-domains` to control which domains are allowed to use DNSLink resolution. This provides a safelist mechanism for DNSLink, improving security for public gateway deployments.

## Problem
Previously, Rainbow would resolve DNSLink for any domain passed via the Host header, which is not ideal for public HTTP servers. There was no way to restrict DNSLink resolution to specific trusted domains.

## Solution
- Added new CLI flag `--dnslink-gateway-domains` (and env var `RAINBOW_DNSLINK_GATEWAY_DOMAINS`)
- When set, only domains in this list (and their subdomains) can use DNSLink resolution
- When not set, maintains backward compatibility (all domains allowed)
- Follows similar pattern to existing gateway domain configurations

## Changes
- Added flag definition in `main.go`
- Added `DNSLinkGatewayDomains` field to Config struct in `setup.go`
- Modified `setupGatewayHandler` in `handlers.go` to check allowed domains before enabling DNSLink
- Added display of configured domains in startup output

## Testing
Tested with various domain configurations:
- Without flag: all domains can use DNSLink (backward compatible)
- With flag: only listed domains can use DNSLink
- Subdomain matching works (e.g., sub.example.com matches example.com)

## Screenshots
<img width="757" height="944" alt="image" src="https://github.com/user-attachments/assets/04329070-6804-4c24-9dd4-af20648887bc" />
<img width="477" height="756" alt="image" src="https://github.com/user-attachments/assets/12149545-e139-4545-9bef-1d4c2f6dad56" />


## Usage Example
```bash
# Allow DNSLink only for specific domains
rainbow --dnslink-gateway-domains="example.com,mysite.org"

# Or via environment variable
RAINBOW_DNSLINK_GATEWAY_DOMAINS="example.com,mysite.org" rainbow

Reviewer @lidel 