### PR TITLE
feat: add BITSWAP_ENABLE_DUPLICATE_BLOCK_STATS environment flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -300,6 +300,12 @@ Generate an identity seed and launch a gateway:
 			EnvVars: []string{"BITSWAP_WANTHAVE_REPLACE_SIZE"},
 			Usage:   "Replace WantHave with WantBlock responses for small blocks up to this size, 0 to disable replacement",
 		},
+		&cli.BoolFlag{
+			Name:    "bitswap-enable-duplicate-block-stats",
+			Value:   false,
+			EnvVars: []string{"BITSWAP_ENABLE_DUPLICATE_BLOCK_STATS"},
+			Usage:   "Enable bitswap duplicate block statistics collection (useful for investigation, has performance overhead)",
+        },
 		&cli.StringSliceFlag{
 			Name:    "remote-backends",
 			Value:   cli.NewStringSlice(),
@@ -661,6 +667,7 @@ share the same seed as long as the indexes are different.
 			DHTSharedHost:              cctx.Bool("dht-shared-host"),
 			Bitswap:                    bitswap,
 			BitswapWantHaveReplaceSize: cctx.Int("bitswap-wanthave-replace-size"),
+			BitswapEnableDuplicateBlockStats: cctx.Bool("bitswap-enable-duplicate-block-stats"),
 			IpnsMaxCacheTTL:            cctx.Duration("ipns-max-cache-ttl"),
 			DenylistSubs:               cctx.StringSlice("denylists"),
 			Peering:                    peeringAddrs,

--- a/setup.go
+++ b/setup.go
@@ -121,6 +121,7 @@ type Config struct {
 	// value. Set to zero to disable replacement and avoid block size lookup
 	// when processing HaveWant requests.
 	BitswapWantHaveReplaceSize int
+	BitswapEnableDuplicateBlockStats bool
 
 	DenylistSubs []string
 

--- a/setup_bitswap.go
+++ b/setup_bitswap.go
@@ -73,9 +73,12 @@ func setupBitswapExchange(ctx context.Context, cfg Config, h host.Host, cr routi
 	clientOpts := []bsclient.Option{
 		bsclient.RebroadcastDelay(rebroadcastDelay),
 		bsclient.ProviderSearchDelay(providerSearchDelay),
-		bsclient.WithoutDuplicatedBlockStats(),
 		bsclient.WithDefaultProviderQueryManager(false), // we pass it in manually
 	}
+
+	if !cfg.BitswapEnableDuplicateBlockStats {
+   	 clientOpts = append(clientOpts, bsclient.WithoutDuplicatedBlockStats())
+    }
 
 	// If peering and shared cache are both enabled, we initialize both a
 	// Client and a Server with custom request filter and custom options.


### PR DESCRIPTION
Fixes: #159 

## Add environment flag to enable bitswap duplicate block statistics

### Problem
Rainbow currently runs with `bsclient.WithoutDuplicatedBlockStats()` hardcoded, which disables duplicate block statistics collection. This makes it difficult to investigate block duplication issues on specific deployment boxes.

### Solution
- Added CLI flag **--bitswap-enable-duplicate-block-stats**  
- Added **BITSWAP_ENABLE_DUPLICATE_BLOCK_STATS** env var support
- Made **WithoutDuplicatedBlockStats()** conditional based on config

### Screenshot
<img width="954" height="1646" alt="image" src="https://github.com/user-attachments/assets/466d0efb-4d84-4d3f-8770-18210b610b57" />
